### PR TITLE
Update Auth.php

### DIFF
--- a/controllers/Auth.php
+++ b/controllers/Auth.php
@@ -50,11 +50,11 @@ class Auth extends ApiController
            // Register, no need activation
            $user = AuthBase::register($data, true);
 
-           Event::fire('octobro.oauth2.register', [$user, $data]);
+           $response = Authorizer::issueAccessToken();
 
            Db::commit();
 
-           return $this->respondWithArray(Authorizer::issueAccessToken());
+           return $this->respondWithArray($response);
 
        } catch (Exception $e) {
            Db::rollBack();


### PR DESCRIPTION
When we trying to register user and doesn't give any of client_id, client_secret, grant_type or username parameters Authorizer exceptions won't be thrown and the user will be created.